### PR TITLE
Add humorous note about needing a friend for demo

### DIFF
--- a/src/components/hang.astro
+++ b/src/components/hang.astro
@@ -5,5 +5,6 @@
 	<div>
 		Want a better demo?
 		<a href="https://hang.live" rel="noreferrer" target="_blank">hang.live</a> uses the same open-source libraries but adds more functionality on top.
+		You'll need a friend though, or at least another tab (I won't judge).
 	</div>
 </div>


### PR DESCRIPTION
## Summary
Updated the hang.live demo callout to include a lighthearted reminder that users need another person (or at least another browser tab) to use the demo.

## Changes
- Added a friendly, humorous note to the demo description clarifying that the demo requires at least two participants or tabs to function properly

## Details
This is a minor UX improvement that sets clearer expectations for users visiting the demo. The added message maintains the casual, friendly tone of the component while providing practical guidance about the demo's requirements.

https://claude.ai/code/session_01PwB7tG42TsWShMo2YuzD6F