### PR TITLE
[codex] move staging site to new domain

### DIFF
--- a/src/pages/blog/update-00.mdx
+++ b/src/pages/blog/update-00.mdx
@@ -138,6 +138,7 @@ The type of output you'd expect from a drone.
 
 Bitrate savings for different configurations:
 |                  | No DEFLATE | DEFLATE per frame | DEFLATE per group |
+| ---------------- | ---------- | ----------------- | ----------------- |
 | No deltas        | 0%         | 39%               | 89%               |
 | JSON Merge Patch | 58%        | 72%               | 91%               |
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,7 +20,7 @@
 		"staging": {
 			"name": "moq-dev-staging",
 			"route": {
-				"pattern": "moq.wtf",
+				"pattern": "new.moq.dev",
 				"custom_domain": true
 			}
 		},

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,7 +20,7 @@
 		"staging": {
 			"name": "moq-dev-staging",
 			"route": {
-				"pattern": "new.moq.dev",
+				"pattern": "cdn.moq.wtf",
 				"custom_domain": true
 			}
 		},

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,7 +20,7 @@
 		"staging": {
 			"name": "moq-dev-staging",
 			"route": {
-				"pattern": "cdn.moq.wtf",
+				"pattern": "new.moq.dev",
 				"custom_domain": true
 			}
 		},


### PR DESCRIPTION
## Summary

- move the staging Worker custom domain from `moq.wtf` to `new.moq.dev`
- update the Pro nav URL so staging points to `https://moq.wtf` and live/local points to `https://moq.pro`
- include the local `update-00` patch-note edits

## Why

`moq.wtf` is being repurposed, so the staging site needs to live at `new.moq.dev` while the Pro link takes over the old staging domain. The existing local patch-note updates are included in the same PR by request.

## Validation

- `bun run check`
- `bun astro build --mode staging`

Note: `bun run check` reports the existing Biome config deprecation info for `recommended`; no check failures.
