### PR TITLE
update moq libraries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,9 @@
     "": {
       "name": "moq.dev",
       "dependencies": {
-        "@moq/boy": "^0.2.10",
-        "@moq/publish": "^0.2.14",
-        "@moq/watch": "^0.2.16",
+        "@moq/boy": "^0.2.12",
+        "@moq/publish": "^0.2.17",
+        "@moq/watch": "^0.2.19",
         "astro": "^5.18.2",
         "highlight.js": "^11.11.1",
         "solid-js": "^1.9.13",
@@ -242,27 +242,29 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@moq/boy": ["@moq/boy@0.2.10", "", { "dependencies": { "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6", "@moq/watch": "^0.2.12", "zod": "^4.3.6" } }, "sha512-dacdswZLDgWh8stsKDLoyBGOSy/5NlNiqbHgXT7GkHpCMqAYs2Y8FKl+eDlYl4NEHt3qpsfGsHV5KeyN0K2a/A=="],
+    "@moq/boy": ["@moq/boy@0.2.12", "", { "dependencies": { "@moq/json": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10", "@moq/watch": "^0.2.19", "zod": "^4.4.3" } }, "sha512-fRFgf5z2jwsy+2vTMBnGPj8Jd2YAvx61PQlBPxyokVFGm+Ulw+4mZoJ5WMgRTScadYsb98uzyCwJK3q1/09UnA=="],
 
-    "@moq/hang": ["@moq/hang@0.2.9", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/loc": "^0.1.0", "@moq/net": "^0.1.4", "@moq/signals": "^0.1.8", "@svta/cml-iso-bmff": "^1.0.2", "zod": "^4.4.3" } }, "sha512-Ib20YX50yCYlHmRM8zWp0kiAKOBTwFzk9lAYLBWJewtkYrmRKmhp++rE8VchwnUE0D4KA/6/zzX4JRH0cmV6CA=="],
+    "@moq/flate": ["@moq/flate@0.1.1", "", { "dependencies": { "pako": "^3.0.0" } }, "sha512-fHuA97OMdvwco/muP01hsg/AxEHzG9Xzr0tuLXI9TXBj7XuZ0uXiIQ4qv26kL6s+emkui/nlieGbr/NvWbPTKQ=="],
 
-    "@moq/json": ["@moq/json@0.0.2", "", { "dependencies": { "@moq/net": "^0.1.3", "@moq/signals": "^0.1.8" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Frk33U521PaYChV6TFFUn+Xdzcig/L3mx2dZdbIARivoZXpadyn7Gz+LvqKrnDqBk1RXDuA+iUiiyHEIHbKizg=="],
+    "@moq/hang": ["@moq/hang@0.2.13", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/json": "^0.1.2", "@moq/loc": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10", "@svta/cml-iso-bmff": "^1.0.2", "zod": "^4.4.3" } }, "sha512-29+z792SGM813JUF7CYgK7e6zbVnlAH4mo0aZ0jpF5uH+lKEVCZ1kSEokNHU2iVVkO0FhEipgf1szcBDfhmqxQ=="],
 
-    "@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
+    "@moq/json": ["@moq/json@0.1.2", "", { "dependencies": { "@moq/flate": "^0.1.1", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-sQz86Iz29lzJIyzY6OtBqJHXxqtcDj2DypPNSEbHSwUQCcOxEzkMS2vhNZEK+oTRN6DpblTmelBeZJPg4RjkjA=="],
 
-    "@moq/loc": ["@moq/loc@0.1.0", "", { "dependencies": { "@moq/net": "^0.1.1" } }, "sha512-8ouPBhoZU/vAaHCrcsi97zOw0BJX/rQbfUJ7Dx2/Cmao6c4knrAXl8EVjlwKM4HLjfa8xzPd4Lqxkfv7G4QyhA=="],
+    "@moq/loc": ["@moq/loc@0.1.2", "", { "dependencies": { "@moq/net": "^0.1.7" } }, "sha512-7hqereQwKCf6JMtKPKskgcSJC3naLQbB5/FsArKRUTMlQIF/QRu3gcaYflW8qSXaHrKm3hmpl7ra/oPLm4F7GA=="],
 
-    "@moq/msf": ["@moq/msf@0.1.1", "", { "dependencies": { "@moq/net": "^0.1.2", "zod": "^4.1.5" } }, "sha512-+Fjw0r4U4FCZS4Lo+pb06+jZqXgMmInNdY7RIZs9M8kDYdkC9wi/hymdIOAcmwr6f1kF9fLNZ7Spfx8oEgcFSg=="],
+    "@moq/msf": ["@moq/msf@0.1.4", "", { "dependencies": { "@moq/net": "^0.1.7", "zod": "^4.4.3" } }, "sha512-cdAcWz3lFCnAu44nf4zsugAp0X84N8w/o/b5rynPMB/1uelXCdQpcbnYUK4kZhq0co8lDM28oAUOGwyL9BjIXg=="],
 
-    "@moq/net": ["@moq/net@0.1.1", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HSyHlktvjt6hQoJYV2I9S7Ugcd6wdtQFwupIPFcYovNIEKCNiLEjSyhxPl/pETruJOu/y45CpNv29/4LN4gpag=="],
+    "@moq/net": ["@moq/net@0.1.7", "", { "dependencies": { "@moq/qmux": "^0.1.3", "@moq/signals": "^0.1.10", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Gzv2fqQXBaKoIqDqkCfuAWsxybtSuro47XY93XpHswKExEEuw7hRJ3C/v5ketj5S0SXXWy/mFKBd5lhdGhE/8Q=="],
 
-    "@moq/publish": ["@moq/publish@0.2.14", "", { "dependencies": { "@moq/hang": "^0.2.9", "@moq/json": "^0.0.2", "@moq/net": "^0.1.4", "@moq/signals": "^0.1.8" } }, "sha512-EdcD6WUwVMT0+cAoHJtO3YfxTamvFTnqu2G4U8VJNc8IgOvlphqR6TBWFdDbNTEG3hu8t5ZB2zkVwiD1M5Z0Sg=="],
+    "@moq/publish": ["@moq/publish@0.2.17", "", { "dependencies": { "@moq/hang": "^0.2.13", "@moq/json": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" } }, "sha512-6qDoh9FxEN3ee/raNnmQ4mTpnbhqcrzAQzft97tPVxZRgzie8vtTlRZYuDobRIYbz6iQ4tlpWuy1Fuc1xuDS6w=="],
 
-    "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
+    "@moq/qmux": ["@moq/qmux@0.1.3", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA=="],
 
-    "@moq/signals": ["@moq/signals@0.1.6", "", { "peerDependencies": { "@types/react": "^19.1.8", "react": "^19.0.0", "solid-js": "^1.9.7" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-ic7ttiz6dHXOPoVAfhz4K6LGT2LWdDGTi1x2u8sYSGZ5nOKGWfqDkwYcGvCPlcVQetn3PaeXYSPFiMAC6RO3tQ=="],
+    "@moq/signals": ["@moq/signals@0.1.10", "", { "peerDependencies": { "@types/react": "^19.2.17", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-TSnQwcaywn/gIwC3UpwZbqYnXm2Zo8KZO6Y043jPiPnbnSlFWJVZ9TVdGAvQqrXGiaNihdcioF/0IEDABsfovw=="],
 
-    "@moq/watch": ["@moq/watch@0.2.16", "", { "dependencies": { "@moq/hang": "^0.2.9", "@moq/json": "^0.0.2", "@moq/msf": "^0.1.1", "@moq/net": "^0.1.4", "@moq/signals": "^0.1.8" } }, "sha512-p8s99gUt03/WywyMlbRqiUnrItTK+J4NG1qdXeh6ol6HaS2QtcKZVXK+DOICSQjhW5uBu8PF5L/aDEetO5BGNA=="],
+    "@moq/watch": ["@moq/watch@0.2.19", "", { "dependencies": { "@moq/hang": "^0.2.13", "@moq/json": "^0.1.2", "@moq/msf": "^0.1.4", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" } }, "sha512-vSNcRUyOzUArabfMljf+DTP5gnM/Z0lSuZM/hoszLWK88PdU+ddckHF90q1IGg3pJl7Ti26voQ6ayFhM8bKFWA=="],
+
+    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.0", "", {}, "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -864,6 +866,8 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "pako": ["pako@3.0.1", "", {}, "sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse-latin": ["parse-latin@7.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "@types/unist": "^3.0.0", "nlcst-to-string": "^4.0.0", "unist-util-modify-children": "^4.0.0", "unist-util-visit-children": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ=="],
@@ -1156,27 +1160,11 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
-    "@moq/boy/@moq/watch": ["@moq/watch@0.2.12", "", { "dependencies": { "@moq/hang": "^0.2.6", "@moq/msf": "^0.1.0", "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6" } }, "sha512-BK0NlzlnSo34qNyvGKQwdCZMu8ZJfItbTmaQoFjQq2+y1xgG7IMnvi2MU9Qdsyc8QeKqzEd4xTjDPKoR1uJpLA=="],
-
-    "@moq/hang/@moq/net": ["@moq/net@0.1.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Wb05fX376DlIP+ttijJLsKbeBL5+6aVFP2bX135MmYB0Ftz/inIHipl2dNnLoKiwzBo9uy1RQ9Vy2PB3OZz0Dw=="],
-
-    "@moq/hang/@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
+    "@moq/boy/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@moq/hang/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@moq/json/@moq/net": ["@moq/net@0.1.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Wb05fX376DlIP+ttijJLsKbeBL5+6aVFP2bX135MmYB0Ftz/inIHipl2dNnLoKiwzBo9uy1RQ9Vy2PB3OZz0Dw=="],
-
-    "@moq/json/@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
-
-    "@moq/msf/@moq/net": ["@moq/net@0.1.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Wb05fX376DlIP+ttijJLsKbeBL5+6aVFP2bX135MmYB0Ftz/inIHipl2dNnLoKiwzBo9uy1RQ9Vy2PB3OZz0Dw=="],
-
-    "@moq/publish/@moq/net": ["@moq/net@0.1.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Wb05fX376DlIP+ttijJLsKbeBL5+6aVFP2bX135MmYB0Ftz/inIHipl2dNnLoKiwzBo9uy1RQ9Vy2PB3OZz0Dw=="],
-
-    "@moq/publish/@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
-
-    "@moq/watch/@moq/net": ["@moq/net@0.1.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.8", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Wb05fX376DlIP+ttijJLsKbeBL5+6aVFP2bX135MmYB0Ftz/inIHipl2dNnLoKiwzBo9uy1RQ9Vy2PB3OZz0Dw=="],
-
-    "@moq/watch/@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
+    "@moq/msf/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -1233,12 +1221,6 @@
     "@astrojs/markdown-remark/shiki/@shikijs/themes": ["@shikijs/themes@3.19.0", "", { "dependencies": { "@shikijs/types": "3.19.0" } }, "sha512-H36qw+oh91Y0s6OlFfdSuQ0Ld+5CgB/VE6gNPK+Hk4VRbVG/XQgkjnt4KzfnnoO6tZPtKJKHPjwebOCfjd6F8A=="],
 
     "@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@3.19.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-Z2hdeEQlzuntf/BZpFG8a+Fsw9UVXdML7w0o3TgSXV3yNESGon+bs9ITkQb3Ki7zxoXOOu5oJWqZ2uto06V9iQ=="],
-
-    "@moq/boy/@moq/watch/@moq/hang": ["@moq/hang@0.2.6", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/loc": "^0.1.0", "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6", "@svta/cml-iso-bmff": "^1.0.0-alpha.9", "zod": "^4.1.5" } }, "sha512-nTSd3BwfpMimsJb7AJAWscDsMmZN24qD6IjcLxyBZoOXtuAroVy/kvfWKjxUizlkMCKcryO5duH7VYdMQSKMdg=="],
-
-    "@moq/boy/@moq/watch/@moq/msf": ["@moq/msf@0.1.0", "", { "dependencies": { "@moq/lite": "^0.2.1", "zod": "^4.1.5" } }, "sha512-5Y/RcxxofBXQSdy6IexzB8s2rpRI7xFiut1Zh6WO6hjNNqM+WKPPt+CTGKqnnnx/vhecgKrvpHnN228Zc0bakg=="],
-
-    "@moq/msf/@moq/net/@moq/signals": ["@moq/signals@0.1.8", "", { "peerDependencies": { "@types/react": "^19.2.15", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-UUbnyyJATCZBpjRjcZZq0vsA6Dc+HcEhNkUF8/eaR9Vkh9m2XTKPY7Oo4XyNiAoAAfI40+LxlI4QT5vv1KJKWA=="],
 
     "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -1299,8 +1281,6 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "@moq/boy/@moq/watch/@moq/hang/@svta/cml-iso-bmff": ["@svta/cml-iso-bmff@1.0.1", "", { "peerDependencies": { "@svta/cml-utils": "1.4.0" } }, "sha512-MOhATJYQ6cVrIcoY3nj8p/vGYDpG3wjQIIhBPHNt9yjFijdwFdBNqdZbCXv3aFhRjdx5Saca5TkgNJusKhnI/w=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 		"fix": "biome check --write && bun audit fix"
 	},
 	"dependencies": {
-		"@moq/boy": "^0.2.10",
-		"@moq/publish": "^0.2.14",
-		"@moq/watch": "^0.2.16",
+		"@moq/boy": "^0.2.12",
+		"@moq/publish": "^0.2.17",
+		"@moq/watch": "^0.2.19",
 		"astro": "^5.18.2",
 		"highlight.js": "^11.11.1",
 		"solid-js": "^1.9.13",


### PR DESCRIPTION
## Summary

Updates the site's direct MoQ npm dependencies to the latest published versions:

- `@moq/boy` to `^0.2.12`
- `@moq/publish` to `^0.2.17`
- `@moq/watch` to `^0.2.19`

The lockfile was regenerated, which also updates and deduplicates the related transitive `@moq/*` packages.

## Validation

- `bun run check`
- `bun run build`