### PR TITLE
Remove hang.live homepage ad

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -10,21 +10,8 @@ layout: "@/layouts/global.astro"
 a super-charged TCP/UDP replacement that powers [HTTP/3](https://en.wikipedia.org/wiki/HTTP/3).
 It's being developed by the [IETF](https://www.ietf.org/) and your _favorite_ big tech companies such as Google, Cisco, Akamai, Cloudflare, etc.
 
-MoQ supports **real-time latency**, scales out via **generic CDNs**, and **works in browsers**.
-You no longer need to hack WebRTC!
-
-<div class="flex items-center gap-8">
-	<a href="https://hang.live" rel="noreferrer" target="_blank">
-		<img src="/hang.svg" class="w-32" alt="hang.live" />
-	</a>
-	<div>
-		Want to hang? <a href="https://hang.live" rel="noreferrer" target="_blank">hang.live</a> is a full conferencing app that uses MoQ for EVERYTHING.
-		It's <a href="https://github.com/moq-dev/hang.live">open source</a> too!
-	</div>
-</div>
-
-But MoQ is more than just a [WebRTC replacement](./blog/replacing-webrtc); it's a [HLS/DASH](./blog/replacing-hls-dash) and [RTMP/SRT](./blog/on-a-boat) replacement too!
-Support **contribution**, mass **distribution**, multiple **latency targets**, **generic** live tracks, and more with an extensible protocol.
+MoQ supports **real-time latency**, scales via **generic CDNs**, and **works in browsers**.
+It replaces [WebRTC](./blog/replacing-webrtc), [HLS/DASH](./blog/replacing-hls-dash), and [RTMP/SRT](./blog/on-a-boat) with one extensible protocol for **contribution**, mass **distribution**, multiple **latency targets**, and **generic** live tracks.
 
 But seriously, <a href="/demo">try the demos already</a>. There's even a gameboy emulator. Don't pretend like you're not excited.
 


### PR DESCRIPTION
## Summary
- remove the hang.live advertisement from the homepage
- tighten the introductory copy by combining two paragraphs

## Verification
- bun run check
- bun run build
- rendered and reviewed the homepage locally