### PR TITLE
Fix horizontal scrolling on blog posts

### DIFF
--- a/src/layouts/global.astro
+++ b/src/layouts/global.astro
@@ -66,7 +66,7 @@ const proUrl = import.meta.env.MODE === "staging" ? "https://moq.wtf" : "https:/
 		<meta name="theme-color" content="#0f172a" />
 	</head>
 	<body class="min-h-screen bg-slate-900 flex justify-center">
-		<div class="flex flex-col md:flex-row gap-0 bg-slate-900 shadow-2xl max-w-6xl w-full p-4">
+		<div class="flex flex-col md:flex-row gap-0 bg-slate-900 shadow-2xl max-w-6xl w-full min-w-0 p-4">
 			<nav class="flex flex-row items-center md:flex-col md:gap-12 gap-4 md:w-64 w-full p-4">
 				<div class="w-1/2 md:w-full flex justify-center">
 					<a href="/">
@@ -112,7 +112,7 @@ const proUrl = import.meta.env.MODE === "staging" ? "https://moq.wtf" : "https:/
 					</a>
 				</div>
 			</nav>
-			<article class="markdown p-4 flex-1">
+			<article class="markdown p-4 flex-1 min-w-0">
 				{
 					frontmatter?.date && (
 						<p class="text-sm text-gray-400 text-right">

--- a/src/layouts/global.css
+++ b/src/layouts/global.css
@@ -25,6 +25,25 @@ pre code.hljs {
 		@apply prose-img:rounded-lg;
 		@apply prose-figure:object-center prose-figure:text-center prose-img:m-auto;
 		@apply prose-a:font-bold prose-a:text-green-500 prose-a:underline prose-a:decoration-green-500 prose-a:decoration-2 prose-a:underline-offset-4;
+
+		/* Long URLs and inline `code` shouldn't push the page wider than the viewport. */
+		@apply break-words;
+	}
+
+	/* Wide tables scroll on their own instead of widening the page. `display: block`
+	   turns the table into the scroll container; the rows still lay out as a table
+	   inside it. Specificity is .markdown table (0,1,1) so it beats the prose
+	   plugin's .prose :where(table) (0,1,0) regardless of layer ordering. */
+	.markdown table {
+		display: block;
+		width: 100%;
+		max-width: 100%;
+		overflow-x: auto;
+	}
+
+	/* Embeds (YouTube, etc) that declare a fixed pixel width. */
+	.markdown iframe {
+		max-width: 100%;
 	}
 
 	.tagline {

--- a/src/pages/blog/first-cdn.mdx
+++ b/src/pages/blog/first-cdn.mdx
@@ -138,7 +138,7 @@ Okay they didn't say that, but this is **exactly** the mentality that MoQ needs 
 **Just do it**.
 
 <figure>
-	<iframe width="560" height="315" src="https://www.youtube.com/embed/ZXsQAXx_ao0?si=xsAscm04CnwAer4b" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="margin: 0 auto;"></iframe>
+	<iframe src="https://www.youtube.com/embed/ZXsQAXx_ao0?si=xsAscm04CnwAer4b" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen style="margin: 0 auto; width: 560px; max-width: 100%; aspect-ratio: 16 / 9;"></iframe>
 	<figcaption>Holy shit I'm Shia LaBeouf.</figcaption>
 </figure>
 


### PR DESCRIPTION
Blog posts scrolled horizontally, most visibly on mobile.

Code blocks were the suspected cause, and they were part of it — but sweeping all 25 pages at 320/375/768/1280px turned up **four** independent causes.

## What changed

**Code blocks** — `<pre>` already had `overflow-x: auto` from the prose plugin, so the interesting question was why it wasn't working. The layout wrapper and `<article>` are flex items, which default to `min-width: auto`: refuse to shrink below the content's intrinsic width. The wide `<pre>` therefore widened the whole page instead of scrolling itself. Adding `min-w-0` to both in `global.astro` is what actually makes the existing overflow rule take effect.

**Tables** — no scroll container, so a wide table (the congestion-control table in `replacing-webrtc`) pushed the page out. Now `display: block` + `overflow-x: auto`.

**Long inline tokens** — unbreakable strings like the inline code `relay.cloudflare.mediaoverquic.com` overflowed their paragraph. Added `break-words`.

**A hardcoded YouTube embed** — `first-cdn.mdx` used `<iframe width="560">` with no responsive cap. This was the single largest overflow (217px) and was invisible to the code-block theory. Replaced the fixed `width`/`height` attributes with `max-width: 100%` plus `aspect-ratio: 16 / 9`.

## Notes for review

- **Tables use `width: 100%`, not `width: max-content`.** My first attempt used the common GitHub-style `max-content`, which scrolls correctly but shrank desktop tables from 864px to 429px. `width: 100%` scrolls on mobile *and* preserves the existing full-width desktop appearance.
- **`.markdown table` is deliberately `(0,1,1)` specificity** so it beats the prose plugin's `.prose :where(table)` `(0,1,0)` regardless of how the layers end up ordered.
- The table and iframe rules are scoped to `.markdown`, so future posts are covered automatically.

## Verification

Measured in-browser rather than eyeballed:

- **Zero overflow** (`scrollWidth - clientWidth`) across all 25 pages × 4 viewport widths, ignoring elements legitimately clipped by a scroll ancestor.
- **No desktop regression** — table columns stay aligned under `display: block` and tables remain 832px wide; the YouTube embed still renders 560×315 on desktop and 311×175 on mobile, 16:9 preserved at both.
- `bunx biome check` and `bun run build` pass. (Biome reports one pre-existing config-migration info, unrelated to this change.)

`bunx astro check` was skipped — it wanted to install `@astrojs/check`, and I didn't want to add a dependency uninvited.

(written by Opus 5)