### PR TITLE
Update MoQ JavaScript packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,9 @@
     "": {
       "name": "moq.dev",
       "dependencies": {
-        "@moq/boy": "^0.2.12",
-        "@moq/publish": "^0.2.17",
-        "@moq/watch": "^0.2.19",
+        "@moq/boy": "^0.3.0",
+        "@moq/publish": "^0.4.2",
+        "@moq/watch": "^0.4.3",
         "astro": "^5.18.2",
         "highlight.js": "^11.11.1",
         "solid-js": "^1.9.13",
@@ -238,33 +238,33 @@
 
     "@libav.js/types": ["@libav.js/types@6.8.8", "", {}, "sha512-Lbik/0Q3x2R8cI7mOtRgt+nUWLqGXh7UinMndmpdXSDY4YEjYyVUDsq6fxkuriL78+LCYx8frZIN1r+oDsvYCQ=="],
 
-    "@libav.js/variant-opus-af": ["@libav.js/variant-opus-af@6.8.8", "", {}, "sha512-8KBQyA8n5goN7lyctOaPxpcx7dapOgqKh8dWW/NAcl87AgM/WoUGSex3fFc46oCtTHYrUKEm1OmZUrtkt3Q56A=="],
+    "@libav.js/variant-opus-af": ["@libav.js/variant-opus-af@6.9.8", "", {}, "sha512-4v4kBOoNnmafubEiBof+ATtr7KcU2/kL+G2hXU61orvC4Lt5OViBXnHdUHCh5ZSQQSmx9nOFEgbYGGYTrBufXQ=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@moq/boy": ["@moq/boy@0.2.12", "", { "dependencies": { "@moq/json": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10", "@moq/watch": "^0.2.19", "zod": "^4.4.3" } }, "sha512-fRFgf5z2jwsy+2vTMBnGPj8Jd2YAvx61PQlBPxyokVFGm+Ulw+4mZoJ5WMgRTScadYsb98uzyCwJK3q1/09UnA=="],
+    "@moq/boy": ["@moq/boy@0.3.0", "", { "dependencies": { "@moq/json": "^0.3.0", "@moq/net": "^0.2.0", "@moq/signals": "^0.2.0", "@moq/watch": "^0.4.0", "zod": "^4.4.3" } }, "sha512-9GSTOxRN3vy1QMN5jKGz8bcSLfEN95lT/SQLj1/pPlKoCBP6L/SBZbxI2TOl5ydRVBUKzsv6EsLcpXDz5aYNWQ=="],
 
     "@moq/flate": ["@moq/flate@0.1.1", "", { "dependencies": { "pako": "^3.0.0" } }, "sha512-fHuA97OMdvwco/muP01hsg/AxEHzG9Xzr0tuLXI9TXBj7XuZ0uXiIQ4qv26kL6s+emkui/nlieGbr/NvWbPTKQ=="],
 
-    "@moq/hang": ["@moq/hang@0.2.13", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/json": "^0.1.2", "@moq/loc": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10", "@svta/cml-iso-bmff": "^1.0.2", "zod": "^4.4.3" } }, "sha512-29+z792SGM813JUF7CYgK7e6zbVnlAH4mo0aZ0jpF5uH+lKEVCZ1kSEokNHU2iVVkO0FhEipgf1szcBDfhmqxQ=="],
+    "@moq/hang": ["@moq/hang@0.3.3", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.9.8", "@moq/json": "^0.3.0", "@moq/loc": "^0.2.0", "@moq/net": "^0.2.2", "@moq/signals": "^0.2.0", "@svta/cml-iso-bmff": "^1.0.2", "zod": "^4.4.3" } }, "sha512-Z8TnZ5ckWv7ogywhU+HCrihLOcjSdSEyXbXoyq/6xDIqB+72CP3tVO+Txp281I6lil0Xms6xCw3QkQbfPyu6rQ=="],
 
-    "@moq/json": ["@moq/json@0.1.2", "", { "dependencies": { "@moq/flate": "^0.1.1", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-sQz86Iz29lzJIyzY6OtBqJHXxqtcDj2DypPNSEbHSwUQCcOxEzkMS2vhNZEK+oTRN6DpblTmelBeZJPg4RjkjA=="],
+    "@moq/json": ["@moq/json@0.3.0", "", { "dependencies": { "@moq/flate": "^0.1.1", "@moq/net": "^0.2.0", "@moq/signals": "^0.2.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-fKJVrxEVN7lQk7yYTPsFNHQrlILbEDI+XlKfDt1opB6Pm5lMvxYfZYeuniFEJCBXLrMV6bGRvnMP3yOne8tUvg=="],
 
-    "@moq/loc": ["@moq/loc@0.1.2", "", { "dependencies": { "@moq/net": "^0.1.7" } }, "sha512-7hqereQwKCf6JMtKPKskgcSJC3naLQbB5/FsArKRUTMlQIF/QRu3gcaYflW8qSXaHrKm3hmpl7ra/oPLm4F7GA=="],
+    "@moq/loc": ["@moq/loc@0.2.0", "", { "dependencies": { "@moq/net": "^0.2.0" } }, "sha512-yFf32c8XW7TsREylbgUjPM20Hi15YZy9h+alOIPRHbzqBxBxMy0xFdAoBAKfIKBT0dRYTpolXpicSVBl0CFIJA=="],
 
-    "@moq/msf": ["@moq/msf@0.1.4", "", { "dependencies": { "@moq/net": "^0.1.7", "zod": "^4.4.3" } }, "sha512-cdAcWz3lFCnAu44nf4zsugAp0X84N8w/o/b5rynPMB/1uelXCdQpcbnYUK4kZhq0co8lDM28oAUOGwyL9BjIXg=="],
+    "@moq/msf": ["@moq/msf@0.2.0", "", { "dependencies": { "@moq/net": "^0.2.0", "zod": "^4.4.3" } }, "sha512-gTeWd5/NpzxbYw9Cf8OfE+ltb6e4tNUXzUc+CkXgPRpT9BvRoE+4vYivhpFNd/M9+sTgqQtU2pK91VPbzbbrIg=="],
 
-    "@moq/net": ["@moq/net@0.1.7", "", { "dependencies": { "@moq/qmux": "^0.1.3", "@moq/signals": "^0.1.10", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-Gzv2fqQXBaKoIqDqkCfuAWsxybtSuro47XY93XpHswKExEEuw7hRJ3C/v5ketj5S0SXXWy/mFKBd5lhdGhE/8Q=="],
+    "@moq/net": ["@moq/net@0.2.2", "", { "dependencies": { "@moq/qmux": "^0.3.2", "@moq/signals": "^0.2.0", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-r89NJgf85H8q7egnY0NuVpwcszKJokbhSMxSJhOxt3bSEAFpCSESFT+hOe47lJgXl9hVSs+1ucmlKgQWUYqsGQ=="],
 
-    "@moq/publish": ["@moq/publish@0.2.17", "", { "dependencies": { "@moq/hang": "^0.2.13", "@moq/json": "^0.1.2", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" } }, "sha512-6qDoh9FxEN3ee/raNnmQ4mTpnbhqcrzAQzft97tPVxZRgzie8vtTlRZYuDobRIYbz6iQ4tlpWuy1Fuc1xuDS6w=="],
+    "@moq/publish": ["@moq/publish@0.4.2", "", { "dependencies": { "@moq/hang": "^0.3.3", "@moq/net": "^0.2.2", "@moq/signals": "^0.2.0" } }, "sha512-gLw97oG0LcwRxa1n+SiTmvgU3WCcqTBvRZCDA4MpAXcqKU8X9Lg+SeuGKsF8GCi1q9Kt2i17slKdr2bm+YCEpw=="],
 
-    "@moq/qmux": ["@moq/qmux@0.1.3", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA=="],
+    "@moq/qmux": ["@moq/qmux@0.3.2", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.1" } }, "sha512-8ymBriVxvD5ISfnTJ3k07Zzt4pBOoh/JnulGCjenY2NrUdCr5PUOy42y/9drSXA3SfCfOdaw4A+BSrWN92qVvg=="],
 
-    "@moq/signals": ["@moq/signals@0.1.10", "", { "peerDependencies": { "@types/react": "^19.2.17", "react": "^19.0.0", "solid-js": "^1.9.13" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-TSnQwcaywn/gIwC3UpwZbqYnXm2Zo8KZO6Y043jPiPnbnSlFWJVZ9TVdGAvQqrXGiaNihdcioF/0IEDABsfovw=="],
+    "@moq/signals": ["@moq/signals@0.2.0", "", { "peerDependencies": { "@types/react": "^19.2.17", "react": "^19.0.0", "solid-js": "^1.9.14" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-BwmoJFoSIpkeRczGrNpNHWQTYelOwxuDkJvy9wrQGQn5ltl9vKifhWMpE8dlOgQigdGtwn9lOFkzOxLA0jZWmQ=="],
 
-    "@moq/watch": ["@moq/watch@0.2.19", "", { "dependencies": { "@moq/hang": "^0.2.13", "@moq/json": "^0.1.2", "@moq/msf": "^0.1.4", "@moq/net": "^0.1.7", "@moq/signals": "^0.1.10" } }, "sha512-vSNcRUyOzUArabfMljf+DTP5gnM/Z0lSuZM/hoszLWK88PdU+ddckHF90q1IGg3pJl7Ti26voQ6ayFhM8bKFWA=="],
+    "@moq/watch": ["@moq/watch@0.4.3", "", { "dependencies": { "@moq/hang": "^0.3.3", "@moq/msf": "^0.2.0", "@moq/net": "^0.2.2", "@moq/signals": "^0.2.0", "media-captions": "0.0.18" } }, "sha512-WxB0pfhvoM/L/nhAzBQs960PCNKRmgx6bKeMSBOeN7NoxXJ+JhoNUyfBdHYwjZXiDxKYyfhMbmM+vzNiNJMeLw=="],
 
-    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.0", "", {}, "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ=="],
+    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.1", "", {}, "sha512-VKi/GE/CLqmbEZlgNbBLbAFk2pQTxT+KUD2DjCSoxqZxbS3KBe5BBZ0m3fila4fEGyll2JT5MmgEyVr4zkZEVA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -739,6 +739,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+
+    "media-captions": ["media-captions@0.0.18", "", {}, "sha512-JW18P6FuHdyLSGwC4TQ0kF3WdNj/+wMw2cKOb8BnmY6vSJGtnwJ+vkYj+IjHOV34j3XMc70HDeB/QYKR7E7fuQ=="],
 
     "merge-anything": ["merge-anything@5.1.7", "", { "dependencies": { "is-what": "^4.1.8" } }, "sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 		"fix": "biome check --write && bun audit fix"
 	},
 	"dependencies": {
-		"@moq/boy": "^0.2.12",
-		"@moq/publish": "^0.2.17",
-		"@moq/watch": "^0.2.19",
+		"@moq/boy": "^0.3.0",
+		"@moq/publish": "^0.4.2",
+		"@moq/watch": "^0.4.3",
 		"astro": "^5.18.2",
 		"highlight.js": "^11.11.1",
 		"solid-js": "^1.9.13",

--- a/src/components/publish.tsx
+++ b/src/components/publish.tsx
@@ -4,7 +4,7 @@ import { adjectives, animals, uniqueNamesGenerator } from "unique-names-generato
 import "@moq/publish/support/element";
 import "@moq/publish/element";
 import "@moq/publish/ui";
-import { Lite } from "@moq/publish";
+import { Net } from "@moq/publish";
 
 export default function Publish() {
 	const name = `${uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: "-" })}.hang`;
@@ -53,7 +53,7 @@ export default function Publish() {
 			</div>
 
 			<moq-publish-ui>
-				<moq-publish prop:url={url} prop:name={Lite.Path.from(name)} prop:source="camera">
+				<moq-publish prop:url={url} prop:name={Net.Path.from(name)} prop:source="camera">
 					<video
 						style={{ "max-width": "100%", height: "100%", margin: "0 auto", "border-radius": "1rem" }}
 						autoplay

--- a/src/components/watch-embed.tsx
+++ b/src/components/watch-embed.tsx
@@ -25,7 +25,7 @@ export default function WatchEmbed() {
 	const embedJs = `import * as Watch from "@moq/watch";
 
 // A MoQ connection that is automatically re-established on drop.
-const connection = new Watch.Lite.Connection.Reload({
+const connection = new Watch.Net.Connection.Reload({
     url: new URL("${publicUrl}"),
     enabled: true,
 });
@@ -34,7 +34,7 @@ const connection = new Watch.Lite.Connection.Reload({
 const broadcast = new Watch.Broadcast({
     connection: connection.established,
     enabled: true,
-    name: Watch.Lite.Path.from("${name}"),
+    name: Watch.Net.Path.from("${name}"),
 });
 
 // Synchronize audio and video playback.

--- a/src/components/watch.tsx
+++ b/src/components/watch.tsx
@@ -1,7 +1,7 @@
 import "@moq/watch/support/element";
 import "@moq/watch/element";
 import "@moq/watch/ui";
-import { Lite } from "@moq/watch";
+import { Net } from "@moq/watch";
 
 export default function Watch() {
 	const params = new URLSearchParams(window.location.search);
@@ -18,7 +18,7 @@ export default function Watch() {
 				</a>
 			</div>
 			<moq-watch-ui>
-				<moq-watch prop:url={url} prop:name={Lite.Path.from(name)} prop:muted={true} prop:reload={true}>
+				<moq-watch prop:url={url} prop:name={Net.Path.from(name)} prop:muted={true} prop:reload={true}>
 					<canvas style={{ "max-width": "100%", height: "auto", margin: "0 auto", "border-radius": "1rem" }} />
 				</moq-watch>
 			</moq-watch-ui>


### PR DESCRIPTION
## Summary
- update @moq/boy, @moq/publish, and @moq/watch to their latest releases
- migrate removed Lite exports to the Net namespace
- update the generated watch embed example

## Verification
- just check
- just build
- deployed and smoke-tested on moq.dev
- just test reports no tests found