### PR TITLE
Add Update 01 blog post

### DIFF
--- a/src/pages/blog/update-01.mdx
+++ b/src/pages/blog/update-01.mdx
@@ -1,0 +1,115 @@
+---
+layout: "@/layouts/global.astro"
+title: Update 01
+author: kixelated
+description: moq-lite-05, legacy format import/export, stats, a big moq-net API break, and five new language bindings.
+cover: "/blog/update-00/globe.png"
+date: 2026-07-31
+---
+
+# Update 01
+
+sup nerds.
+
+I hit the merge button on the `dev` branch: +129k -24k
+
+## moq-lite-05
+[Read the draft](https://www.ietf.org/archive/id/draft-lcurley-moq-lite-05.html)
+
+For those unawares, `moq-lite` is my subset of the *official* `moq-transport` draft.
+It's dramatically simpler and honest about supported functionality.
+You know exactly what the peer will support, unlike the sprawling and perpetually optional `moq-transport` draft.
+
+Anyway, here's the new stuff (partially) cherry-picked from `moq-transport`:
+- **FETCH**: Request a single group from the past. Intended for VOD/DVR, similar to HTTP.
+- **DATAGRAMS**: Unreliable and lossy. I still claim you should [never use datagrams](/blog/never-use-datagrams) but they're now an option.
+- **PATH**: For underlying transports without a path: TLS/TCP/UDS.
+
+But `moq-lite` is also a testing ground, extending `moq-transport` with new functionality:
+- **TIMESTAMPS**: Timestamp/timescale is now part of the transport, so relays know accurate expiration times.
+- **HOPS**: Each announcement includes previous hops (prevents cycles) and soon an explicit cost.
+- **PROBE**: The sender can report/probe the estimated send rate, used for ABR.
+
+I've made IETF extensions for these if anybody cares.
+Knock yourself out lul.
+
+## Export/Import
+I want to help you support your crappy legacy formats.
+So you can get one foot in the MoQ door.
+
+- **moq-rtmp**: Import/export RTMP streams.
+- **moq-rtc**: WebRTC support via [WHIP](https://datatracker.ietf.org/doc/rfc9725/) and [WHEP](https://datatracker.ietf.org/doc/draft-ietf-wish-whep/).
+- **moq-srt**: A gross protocol, please stop using it...
+- **moq-hls**: HLS export to both disk and (soon) a live origin. There's also DASH support I guess.
+
+## Stats
+Each relay (or client) can now publish metrics as a `.stats/<node>` broadcast.
+We dog food in this bitch.
+
+We publish cumulative metrics for each broadcast once per second.
+We use JSON Merge patch and gzip to minimize the size of each update.
+There's a **moq-stats** crate to do all of the heavy lifting.
+
+You can run a worker to discover and aggregate all of these metrics.
+That's how [moq.pro](https://moq.pro) works.
+
+There's also `/metrics` for Prometheus if you want to integrate with other stuff.
+Boring.
+
+
+## moq-net API
+I got the feedback that there were too many breaking API changes.
+That's why I'm making one massive breaking change instead.
+ur welcome.
+
+**Rust + JS Stuff**:
+- Moved into modules: ex. `BroadcastConsumer` -> `broadcast::Consumer`.
+- `track::Consumer::subscribe()` returns a `track::Subscriber`, so fetching doesn't require an active subscription.
+
+**JS Only Stuff**:
+- Signals split into `in` and `out` sections, where `out` is read-only.
+
+**Rust Only Stuff**:
+- Global LRU to maximize cache usage, instead of a 5s hard expiration.
+- Route changes no longer sever the subscription!
+
+The last one is cool, although kind of niche.
+If you establish multiple connections that can both serve broadcast A, any subscriptions will prefer the shortest path but seamlessly switch to the other path if the first one fails (or becomes higher cost).
+
+So like... you could connect to both [moq.pro](https://moq.pro) and Cloudflare.
+If one goes down, the other will take over SEAMLESSLY.
+
+
+## Language Bindings
+Rust and TypeScript are the *official* languages we support, but we're adding more languages to the party.
+It's Rust under the hood of course.
+
+Instead of the gross raw **moq-ffi** bindings, there are some "ergonomic" wrappers that feel more native.
+These APIs are vibe coded (I don't know these languages lul) so please raise a stink if any API is gross.
+
+- **Python**: [`moq-rs`](https://pypi.org/project/moq-rs/) on PyPI ([docs](https://moq-rs.readthedocs.io)).
+- **Go**: [`github.com/moq-dev/moq-go`](https://pkg.go.dev/github.com/moq-dev/moq-go).
+- **Kotlin**: [`dev.moq:moq`](https://central.sonatype.com/artifact/dev.moq/moq) on Maven Central ([docs](https://javadoc.io/doc/dev.moq/moq)).
+- **Swift**: [`moq-swift`](https://swiftpackageindex.com/moq-dev/moq-swift/documentation/moq) via SPM.
+- **C**: [`libmoq`](https://docs.rs/libmoq).
+
+Full docs for each language: [doc.moq.dev/lib](https://doc.moq.dev/lib/).
+
+## Native Media
+I got tired of ffmpeg and figured I'd **REWRITE IT IN RUST**.
+
+**Disclaimer**: this stuff is mostly vibe coded. Don't trust it lul.
+
+- **moq-video**: Capture, encode, decode, and render video. Uses hardware acceleration via OS/GPU specific APIs. For example: [moq-nvenc](https://crates.io/crates/moq-nvenc) and [moq-vaapi](https://crates.io/crates/moq-vaapi).
+- **moq-audio**: Capture, encode, decode, and render audio. Duh.
+- **moq-transcode**: On-demand transcoding utilizing FETCH.
+
+We're merging in relevant stuff from [iroh-live](https://github.com/n0-computer/iroh-live) so more features are coming soon.
+These crates will keep evolving as they actually turn into products (and get reviewed lul).
+
+
+## FIN
+IDK what else to say.
+
+Written by [@kixelated](https://github.com/kixelated).
+![@kixelated](/blog/avatar.png)

--- a/src/pages/blog/update-01.mdx
+++ b/src/pages/blog/update-01.mdx
@@ -43,11 +43,11 @@ So you can get one foot in the MoQ door.
 - **moq-hls**: HLS export to both disk and (soon) a live origin. There's also DASH support I guess.
 
 ## Stats
-Each relay (or client) can now publish metrics as a `.stats/<node>` broadcast.
+Each relay (or client) can now publish metrics as a `.stats/node/<node>` broadcast.
 We dog food in this bitch.
 
 We publish cumulative metrics for each broadcast once per second.
-We use JSON Merge patch and gzip to minimize the size of each update.
+We use JSON Merge Patch and DEFLATE to minimize the size of each update, served as a `.json.z` sibling of each plain track.
 There's a **moq-stats** crate to do all of the heavy lifting.
 
 You can run a worker to discover and aggregate all of these metrics.
@@ -100,7 +100,7 @@ I got tired of ffmpeg and figured I'd **REWRITE IT IN RUST**.
 
 **Disclaimer**: this stuff is mostly vibe coded. Don't trust it lul.
 
-- **moq-video**: Capture, encode, decode, and render video. Uses hardware acceleration via OS/GPU specific APIs. For example: [moq-nvenc](https://crates.io/crates/moq-nvenc) and [moq-vaapi](https://crates.io/crates/moq-vaapi).
+- **moq-video**: Capture, encode, decode, and render video. Uses hardware acceleration via OS/GPU-specific APIs. For example: [moq-nvenc](https://crates.io/crates/moq-nvenc) and [moq-vaapi](https://crates.io/crates/moq-vaapi).
 - **moq-audio**: Capture, encode, decode, and render audio. Duh.
 - **moq-transcode**: On-demand transcoding utilizing FETCH.
 


### PR DESCRIPTION
Patch notes for the `dev` branch merge.

## Contents

- **moq-lite-05** - FETCH, DATAGRAMS, PATH, plus the TIMESTAMPS/HOPS/PROBE extensions
- **Export/Import** - moq-rtmp, moq-rtc, moq-srt, moq-hls
- **Stats** - the `.stats/node/<node>` broadcast and the moq-stats crate
- **moq-net API** - the one big breaking change
- **Language Bindings** - Python, Go, Kotlin, Swift, and C, each linked to its registry/doc host
- **Native Media** - moq-video, moq-audio, moq-transcode

## Merging does not publish this

Since #117, nothing ships on merge. The post goes live, and the announcement email goes out, on the next `just deploy live`. Merging here only puts it on `main`.

## Frontmatter

The draft had none, which **hard-fails `just build`**: `src/pages/rss.xml.js` keeps any post with a truthy `frontmatter` object, so a block-less MDX file reaches `@astrojs/rss` as `{title: undefined, description: undefined, pubDate: Invalid Date}` and trips its validation. Note `bun run check` (what `pr.yml` runs) passes either way, so CI would have been green on a build that cannot deploy.

`cover` reuses `/blog/update-00/globe.png` since there is no `public/blog/update-01/` yet. Worth swapping for a post-specific image.

## Review fixes

CodeRabbit caught two factual errors in the Stats section, both confirmed against `rs/moq-stats/src/lib.rs` rather than taken on faith:

- the broadcast path is `<prefix>/node/<node>` (default prefix `.stats`), not `.stats/<node>`
- compression is group-scoped DEFLATE with RFC 7396 merge-patch deltas on a `.json.z` sibling track, not gzip

Plus a compound-modifier hyphen.

## Test plan

- `bun run check` - clean (the one biome "info" is a pre-existing config-migration notice on `biome.jsonc`)
- `just build` - 33 pages, was 32
- Verified every link resolves: the moq-lite-05 draft, `/blog/never-use-datagrams`, RFC 9725, the WHEP draft, iroh-live, all referenced crates on crates.io, and each binding's registry and doc host

## Open item

CodeRabbit reported the Swift Package Index link as a 404. I could not confirm or refute it: SPI returns 403 to every non-browser client, including its own package root, so neither of us actually reached the page. The repo does have a `.spi.yml` (doc generation is opted in) and `doc/lib/swift/index.md` upstream uses this same URL as its canonical API reference, so I left it. Worth opening in a browser once.

## Not included

`open-for-business.mdx` and `voice-ai.mdx` are still untracked drafts. They have the same missing-frontmatter problem and will break the build the same way when they land.

(written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnCscaFDaj6TaBahqxXGqb