### PR TITLE
Fix subscribe dropping every signup

### DIFF
--- a/src/layouts/global.astro
+++ b/src/layouts/global.astro
@@ -10,17 +10,27 @@ interface Props {
 	title: string;
 	description: string;
 
+	// Show the signup form. Blog posts get it automatically; other pages opt in,
+	// since it has no business interrupting the demo and player pages.
+	subscribe?: boolean;
+
 	frontmatter?: {
 		title: string;
 		date: string;
 		description: string;
 		cover?: string;
+		subscribe?: boolean;
 	};
 }
 
 let { title, frontmatter, description } = Astro.props;
+const { subscribe } = Astro.props;
 if (frontmatter?.title) title = frontmatter.title;
 if (frontmatter?.description) description = frontmatter.description;
+
+// `date` is what makes a page a blog post. An explicit flag, from either a prop
+// (.astro pages) or frontmatter (.mdx pages), wins over that default.
+const showSubscribe = subscribe ?? frontmatter?.subscribe ?? Boolean(frontmatter?.date);
 
 const siteUrl = Astro.site?.toString().replace(/\/$/, "") ?? "https://moq.dev";
 const pageUrl = new URL(Astro.url.pathname, siteUrl).toString();
@@ -121,7 +131,7 @@ const proUrl = import.meta.env.MODE === "staging" ? "https://moq.wtf" : "https:/
 					)
 				}
 				<slot />
-				{frontmatter?.date && <Subscribe />}
+				{showSubscribe && <Subscribe />}
 			</article>
 		</div>
 	</body>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -20,7 +20,7 @@ posts.sort((a, b) => {
 });
 ---
 
-<MainLayout title="Blog" description="Blog posts and fun stuff">
+<MainLayout title="Blog" description="Blog posts and fun stuff" subscribe>
 	<section>
 		<div class="flex items-center justify-between mb-6">
 			<h1>Blog Posts</h1>

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -48,7 +48,9 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
 			body: JSON.stringify({
 				email,
 				unsubscribed: false,
-				segments: [env.RESEND_SEGMENT_ID],
+				// Objects, not bare ids. A string here is a 422 that used to be reported
+				// to the visitor as success, so every signup was dropped on the floor.
+				segments: [{ id: env.RESEND_SEGMENT_ID }],
 			}),
 		});
 	} catch (err) {
@@ -56,14 +58,13 @@ async function handleSubscribe(request: Request, env: Env): Promise<Response> {
 		return json({ error: "subscribe failed" }, 502);
 	}
 
-	// Treat any non-5xx as success so we don't leak whether an address is
-	// already on the list (Resend returns 4xx for duplicates). Log 4xx for
-	// debugging since a misconfigured segment ID would silently break sends.
+	// Resend upserts contacts: re-subscribing an existing address returns 201 with
+	// the same contact id, so there is no duplicate to hide and no reason to
+	// swallow a 4xx. Anything not ok is a real failure (malformed body, unknown
+	// segment), and calling those success is what silently discarded every signup.
 	// Only log status + request id, not the body (which may contain the email).
 	if (!res.ok) {
 		console.error(`Resend POST /contacts → ${res.status} (request-id: ${res.headers.get("x-request-id") ?? "n/a"})`);
-	}
-	if (res.status >= 500) {
 		return json({ error: "subscribe failed" }, 502);
 	}
 


### PR DESCRIPTION
## Summary

`/api/subscribe` has never created a contact. Both Resend audiences are empty, which is why no announcement has ever had anyone to go to.

**Root cause:** Resend's `POST /contacts` takes `segments` as an array of objects. `worker/index.ts` sent an array of ids:

```js
segments: [env.RESEND_SEGMENT_ID],        // 422 Invalid input: expected object, received string
segments: [{ id: env.RESEND_SEGMENT_ID }] // 201 contact created
```

**Why it stayed hidden:** the handler treated any non-5xx as success, deliberately, so a repeat signup would not reveal that an address was already on the list. But 422 is non-5xx, so the visitor saw "Thanks!" while the contact was discarded. The premise turns out to be wrong anyway: Resend upserts, and a duplicate signup returns 201 with the same contact id, so there was never a duplicate case to hide. A non-ok response now returns an error, which `subscribe.tsx` already renders.

The API key and segment id were both fine. The 422 (rather than a 401) is itself evidence the key was valid and reaching Resend.

## Changes

- `worker/index.ts`: correct `segments` shape; stop reporting failures as success.
- `src/layouts/global.astro`: `subscribe` prop / frontmatter flag, so a page can show the form without having a `date`.
- `src/pages/blog/index.astro`: opt the blog index in.

## Test plan

Verified against the real Resend API, then cleaned up. Both audiences are back to 0 contacts and the only contacts that ever existed were the test ones below, all deleted.

Request shape, same address and segment, only the shape differing:

| Body | Result |
|---|---|
| `segments: ["7bfda95d-…"]` | 422 `Invalid input: expected object, received string` |
| `segments: [{"id": "7bfda95d-…"}]` | 201 contact created |

Duplicate behaviour, disproving the original comment: posting the same address twice returned 201 both times with the identical contact id.

End-to-end through the worker under `wrangler dev`:

- valid signup -> `{"ok":true}` 200, and the contact appeared in the Blog segment
- malformed email -> `{"error":"invalid email"}` 400, no API call
- bogus `RESEND_SEGMENT_ID` -> `{"error":"subscribe failed"}` 502, where the old code returned `{"ok":true}` 200

Form placement, from the built output:

| Page | Form |
|---|---|
| `/blog` index | yes |
| blog posts | yes |
| homepage, `/watch`, `/demo`, `/publish`, `/boy`, `/source`, `/issues`, 404 | no |

`bun run check` and `just build` clean.

## Note

Anyone who tried to subscribe before this is unrecoverable beyond what is in the Workers logs. The fix does not take effect until the next `just deploy live`.

(written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnCscaFDaj6TaBahqxXGqb