### PR TITLE
Match subscribe form to site styling

### DIFF
--- a/src/components/subscribe.astro
+++ b/src/components/subscribe.astro
@@ -3,13 +3,15 @@ import Subscribe from "@/components/subscribe.tsx";
 ---
 
 <aside class="not-prose mt-12 border-t border-slate-700 pt-8">
-	<h3 class="mb-4 text-xl font-semibold text-slate-100">Subscribe for new stuff</h3>
+	<h3 class="mb-4 text-xl font-semibold text-slate-100 underline decoration-green-500 decoration-2 underline-offset-4">
+		Subscribe for new stuff
+	</h3>
 	<Subscribe client:load />
 	<div class="mt-4 flex items-center gap-2 text-sm text-slate-400">
 		<span>or</span>
 		<a
 			href="/rss.xml"
-			class="inline-flex items-center gap-1.5 text-slate-300 hover:text-white"
+			class="inline-flex items-center gap-1.5 text-slate-300 transition-colors hover:text-green-500"
 			title="RSS Feed"
 		>
 			<svg width="18" height="18" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="RSS Feed">

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -45,12 +45,12 @@ export default function Subscribe() {
 						value={email()}
 						onInput={(e) => setEmail(e.currentTarget.value)}
 						disabled={state() === "submitting"}
-						class="flex-1 rounded border border-slate-700 bg-slate-800 px-3 py-2 text-slate-100 placeholder-slate-500 focus:border-blue-500 focus:outline-none"
+						class="flex-1 rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-slate-100 placeholder-slate-500 transition-colors focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500 disabled:cursor-not-allowed disabled:opacity-60"
 					/>
 					<button
 						type="submit"
 						disabled={state() === "submitting"}
-						class="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-500 disabled:bg-slate-700"
+						class="rounded-lg bg-green-500 px-5 py-2 font-bold text-slate-950 transition-colors hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:bg-slate-700 disabled:text-slate-400"
 					>
 						{state() === "submitting" ? "Subscribing…" : "Subscribe"}
 					</button>


### PR DESCRIPTION
## Summary

- restyle the subscribe button with the site's green accent
- add matching green focus treatments to the email field
- align the heading underline and RSS hover state with the site's visual language
- improve hover, focus, and disabled interaction states

## Why

The subscribe form used a blue call-to-action and focus state that did not match the green accent used throughout moq.dev. This makes the form feel consistent with the rest of the site while preserving its responsive layout and behavior.

## Validation

- `just check`
- `just build`