### PR TITLE
Route /api/* through the Worker so subscribe actually runs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,9 +15,10 @@
 		"binding": "ASSETS",
 
 		// Static assets are normally served before the Worker ever runs, which
-		// would skip the de.moq.dev -> /de rewrite for "/". Route just the root
-		// through the Worker; everything else still short-circuits to assets.
-		"run_worker_first": ["/"]
+		// would skip the de.moq.dev -> /de rewrite for "/" and swallow POSTs to
+		// /api/* with a bare 405. Route those through the Worker; everything else
+		// still short-circuits to assets.
+		"run_worker_first": ["/", "/api/*"]
 	},
 
 	// Environment-specific configurations


### PR DESCRIPTION
## What

One line in `wrangler.jsonc`: `run_worker_first` now lists `/api/*` alongside `/`.

## Why

`just deploy live` failed its announce step with a Resend 422: *"The audience you are sending has no contacts."* The audience is empty because the subscribe form has never worked.

`run_worker_first` only listed `"/"`, so for every other path Cloudflare's static asset server answers before the Worker runs. `/api/subscribe` isn't an asset, and the asset server rejects a POST to a non-asset path with a bare 405 — the Worker's `handleSubscribe` never executes.

Confirmed against production:

- `POST https://moq.dev/api/subscribe` → `405` with an empty body. The Worker's own 405 branch returns the string `Method Not Allowed`, so this response isn't coming from our code.
- `GET https://moq.dev/api/subscribe` → the asset `404` page.
- `new.moq.dev` behaves the same way.

So every visitor who submitted the form got "Something went wrong. Try again?" and their address was silently dropped.

The rest of the chain is healthy and needed no changes: `RESEND_API_KEY` and `RESEND_SEGMENT_ID` are both set as secrets on the live Worker, and the handler's `POST /contacts` with a `segments: [{ id }]` array matches Resend's current API reference.

This is the same footgun `CLAUDE.md` already documents for moq.pub / moq.watch, where `assets.run_worker_first` is called out as load-bearing — it just bit the moq.dev Worker on a different path.

## Verifying after deploy

```
curl -i -X POST https://new.moq.dev/api/subscribe \
  -H 'Content-Type: application/json' -d '{"email":"you@example.com"}'
```

Should return `200 {"ok":true}` and the address should appear in the Resend "Blog" segment. Before this change it's an empty `405`.

## Not fixed here

- Five orphaned `Untitled` draft broadcasts are sitting in Resend from the deploy retries (15:35–16:06 UTC). Each was created fine and then failed on send. Worth cleaning up in the dashboard.
- The Open For Business announce won't fire on its own anymore — the announce snapshot expires an hour after the first attempt, after which a rerun reads the post as already live. Once the audience has real contacts, that one needs sending by hand.

(written by Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RibbEtTdquFTTLJNEvrAn9