### PR TITLE
Promote DemoQED on the homepage

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -15,6 +15,10 @@ It's being standardized by the [IETF](https://www.ietf.org/) and your _favorite_
 Our goal is to replace [WebRTC](./blog/replacing-webrtc), [HLS/DASH](./blog/replacing-hls-dash), and [RTMP/SRT](./blog/on-a-boat) with one generic/extensible protocol.
 Supports any **latency**, any **scale**, and any **content** (not just media!).
 
+<aside className="not-prose my-8 border-l-4 border-green-500 bg-slate-800/60 px-5 py-4 text-base leading-7 text-slate-200">
+	<a href="https://moqalliance.org/demoqed-2026/" className="font-bold text-white underline decoration-green-500 decoration-4 underline-offset-4">DEMOQED</a> is the first MoQ conference! October 8 in San Francisco, hosted by the <a href="https://moqalliance.org/" className="font-bold text-green-500 underline decoration-2 underline-offset-4">MoQ Alliance</a>.
+</aside>
+
 ### Features
 
 <ul class="list-none pl-0">


### PR DESCRIPTION
## Summary

- add a compact homepage announcement for the first MoQ conference
- link to both DemoQED and the MoQ Alliance
- match the existing slate and green visual language

## Validation

- just check
- desktop and mobile browser preview

(written by GPT-5.6)