### PR TITLE
Check Nix dependencies weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@
 # bypass the cooldown. It only gates Dependabot-driven updates, not a manual
 # `bun update`.
 #
-# Nix flake inputs are updated monthly by Dependabot.
+# Nix flake inputs are updated weekly by Dependabot.
 
 version: 2
 updates:
@@ -38,7 +38,7 @@ updates:
   - package-ecosystem: "nix"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       nix:
         patterns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ just fix           # Auto-fix code formatting/lint issues
 
 The Bun version in nixpkgs must match `packageManager` in `package.json`
 and the base image in `Dockerfile`. CI reads its version from `package.json`
-and evaluates the flake assertions to catch drift. When a monthly Dependabot
+and evaluates the flake assertions to catch drift. When a weekly Dependabot
 Nix update changes Bun, update the other two pins in the same PR.
 
 ### Key Components


### PR DESCRIPTION
Change Dependabot's Nix schedule from monthly to weekly, matching the other ecosystems, and update the accompanying documentation.

Validation: git diff --check passed.

(written by GPT-6)
